### PR TITLE
Fix LED indication on TL-WR840N v6

### DIFF
--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -373,6 +373,11 @@ tplink,tl-wr840n-v4)
 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
 	;;
+tplink,tl-wr840n-v6)
+	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan" "phy0tpt"
+	ucidef_set_led_netdev "lan" "lan" "$boardname:green:lan" "eth0"
+	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
+	;;
 tplink,tl-wr841n-v13)
 	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan" "phy0tpt"
 	ucidef_set_led_switch "lan1" "lan1" "$boardname:green:lan1" "switch0" "0x2"

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v6.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v6.dts
@@ -10,10 +10,10 @@
 	model = "TP-Link TL-WR840N v6";
 
 	aliases {
-		led-boot = &led_power_green;
-		led-failsafe = &led_power_green;
-		led-running = &led_power_green;
-		led-upgrade = &led_power_green;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
 	};
 	
 	memory@0 {
@@ -39,14 +39,24 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_power_green: power {
-			label = "tl-wr840n-v6:green:power";
-			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		lan {
+			label = "tl-wr840n-v6:green:lan";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		};
 
-		orange {
-			label = "tl-wr840n-v6:orange:power";
-			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		wlan {
+			label = "tl-wr840n-v6:green:wlan";
+			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: orange {
+			label = "tl-wr840n-v6:orange:wan";
+			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		green {
+			label = "tl-wr840n-v6:green:wan";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 		};
 	};
 };
@@ -99,7 +109,7 @@
 &pinctrl {
 	state_default: pinctrl0 {
 		gpio {
-			ralink,group = "p0led_an", "p2led_an", "perst";
+			ralink,group = "p1led_an", "p3led_an", "p4led_an", "wled_an", "perst";
 			ralink,function = "gpio";
 		};
 	};


### PR DESCRIPTION
According to the datasheet on mt7628an, I configured the LED indicators to work under TL-WR840N v6. Now they work correctly. It is possible to reassign all the LEDs to your needs using the console or web interface.
